### PR TITLE
Feat: make `lookup_ip` return accesss count

### DIFF
--- a/src/lc_trie.h
+++ b/src/lc_trie.h
@@ -101,11 +101,13 @@ uint32_t count_nodes_trie(TrieNode *trie);
  *
  * @param ip_addr The IP address to look up.
  * @param trie Pointer to the root node of the LC-Trie.
+ * @param[out] access_count Number of node accesses during the lookup. Will be
+ *      overwritten, not added to. Pass NULL to ignore.
  *
  * @return The outgoing interface associated with the longest matching prefix,
  *      or 0 if no rules match.
  */
-uint32_t lookup_ip(ip_addr_t ip_addr, TrieNode *trie);
+uint32_t lookup_ip(ip_addr_t ip_addr, TrieNode *trie, int *access_count);
 
 // Not going to add a 'compress_trie' function since the trie is born
 // compressed

--- a/src/main.c
+++ b/src/main.c
@@ -188,7 +188,7 @@ int profiled_lookup(
     // TODO: Pass tableAccessCount to lookup_ip (check #16)
     // Timed IP lookup
     clock_gettime(CLOCK_MONOTONIC_RAW, &initialTime);
-    outInterface = lookup_ip(ip_address, root);
+    outInterface = lookup_ip(ip_address, root, &tableAccessCount);
     clock_gettime(CLOCK_MONOTONIC_RAW, &finalTime);
 
     double searchingTime; // Set by printOutputLine

--- a/test/proobs.c
+++ b/test/proobs.c
@@ -390,8 +390,10 @@ int test_create_trie() {
 
 // Test wrapper for lookup
 int _test_lookup(ip_addr_t ip, TrieNode *trie, int expected) {
-    int result = lookup_ip(ip, trie);
-    printf("IP: %08X -> Result: %d (Expected: %d)\n\n", ip, result, expected);
+    int access_count = 0;
+    int result = lookup_ip(ip, trie, &access_count);
+    printf("IP: %08X -> Result: %d (Expected: %d) in %d accesses\n",
+            ip, result, expected, access_count);
 
     if (result != expected) {
         TEST_FAIL("Wrong match\n");
@@ -479,8 +481,7 @@ int test_lookup() {
     printf("\n=== Running lookup tests ===\n");
     for (int i = 0; i < sizeof(tests) / sizeof(tests[0]); i++)
     {
-        printf("--- Test Case %d: ", i+1 );
-        printf("%s ---\n", tests[i].description);
+        printf("\n--- Test Case %d: %s ---\n", i+1, tests[i].description);
         fails += _test_lookup(tests[i].ip, trie, tests[i].expected);
     }
 


### PR DESCRIPTION
Added an output parameter `access_count` to `lookup_ip`, which is overwritten with the number of nodes accessed (not counting root).