### PR TITLE
Fix: free rules during cleanup

### DIFF
--- a/src/lc_trie.c
+++ b/src/lc_trie.c
@@ -507,6 +507,37 @@ void free_trie(TrieNode *root) {
     DEBUG_PRINT("--Done freeing tree\n");
 }
 
+void free_trie_rules(TrieNode *root) {
+    DEBUG_PRINT("Freeing rules for trie at %p\n", root);
+    if (root == NULL) {
+        DEBUG_PRINT("--Nothing to free\n");
+        return;
+    }
+
+    // Traverse to a leaf
+    DEBUG_PRINT("  Finding a leaf\n");
+    TrieNode *current = root;
+    while (current->branch != 0) {
+        current = (TrieNode *)current->pointer;
+    }
+    DEBUG_PRINT("  Found leaf at %p\n", current);
+
+    // Traverse to the parent of all rules through the reverse tree
+    Rule *rule = (Rule *)current->pointer;
+    DEBUG_PRINT("  Finding deepest parent for rule at %p: 0x%08X/%hhu\n",
+            rule, rule->prefix, rule->prefix_len);
+    while (rule->parent != NULL) {
+        DEBUG_PRINT("    Found parent at %p: 0x%08X/%hhu\n",
+                rule->parent, rule->parent->prefix, rule->parent->prefix_len);
+        rule = rule->parent;
+    }
+
+    DEBUG_PRINT("  Freeing rules at %p\n", rule);
+    free(rule); // Free the first rule
+
+    DEBUG_PRINT("--Done freeing rules\n");
+}
+
 // ---- Mock implementations for testing ----
 
 #ifdef MOCK

--- a/src/lc_trie.h
+++ b/src/lc_trie.h
@@ -90,6 +90,13 @@ TrieNode *create_trie(Rule *rules, size_t num_rules);
  */
 void free_trie(TrieNode *trie);
 
+/** Free the memory allocated for the LC-Trie's rules. Available in case the
+ *  caller lost the pointer.
+ *
+ * @param trie Pointer to the root node of the LC-Trie.
+ */
+void free_trie_rules(TrieNode *trie);
+
 /** Count the total number of nodes in a given LC-Trie.
  *
  * @param trie Pointer to the root node of the LC-Trie.

--- a/src/main.c
+++ b/src/main.c
@@ -110,9 +110,11 @@ int main(int argc, char *argv[]) {
     printSummary(node_count, i, avg_access_count, avg_search_time);
     DEBUG_PRINT("Summary done\n");
 
-    DEBUG_PRINT("Clean up start\n");
     // Clean up
+    DEBUG_PRINT("Clean up start\n");
     freeIO();
+    // Free the rules because it isn't done anywhere else
+    free_trie_rules(root);
     free_trie(root);
 
     DEBUG_PRINT("Clean up done\n");


### PR DESCRIPTION
Fixes #45

- **Added free_trie_rules() function to lc_trie module**
- **Add call to free_trie_rules during main cleanup**
